### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 %:
-	dh $@ --with autoreconf
+	dh $@
 
 override_dh_missing:
 	dh_missing --fail-missing

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Bug-Database: https://github.com/Snaipe/Criterion/issues
+Bug-Submit: https://github.com/Snaipe/Criterion/issues/new


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Drop unnecessary dependency on dh-autoreconf. ([useless-autoreconf-build-depends](https://lintian.debian.org/tags/useless-autoreconf-build-depends.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/boxfort/053cef02-a2e3-4dbf-8eeb-96eb76cd8f13.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/053cef02-a2e3-4dbf-8eeb-96eb76cd8f13/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/053cef02-a2e3-4dbf-8eeb-96eb76cd8f13/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/053cef02-a2e3-4dbf-8eeb-96eb76cd8f13/diffoscope)).
